### PR TITLE
Update handlePrevSlide

### DIFF
--- a/src/components/MainContainer/index.tsx
+++ b/src/components/MainContainer/index.tsx
@@ -20,7 +20,7 @@ const MainContainer = ({ isDark }: { isDark: boolean }) => {
 
   const handlePrevSlide = () => {
     if (slideIndex === 0) {
-      setSlideIndex((project.length % tabletCardBox) - 1);
+      setSlideIndex(project.length % tabletCardBox);
     } else {
       setSlideIndex(slideIndex - 1);
     }


### PR DESCRIPTION
# 작업내용 🐉

> 첫 화면에서 이전으로 돌아가는 방향의 버튼을 클릭하였을 때 카드 두 개가 스킵되는 문제를 해결하였습니다.
