### PR TITLE
Update mobileSlide

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -17,11 +17,11 @@ const preview: Preview = {
       values: [
         {
           name: 'light',
-          value: '#ffffff',
+          value: '#F1F1F5',
         },
         {
           name: 'dark',
-          value: '#000000',
+          value: '#191919',
         },
       ],
     },

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,7 +1,7 @@
 import { ThemeProvider } from '@emotion/react';
 import type { Preview } from '@storybook/react';
 import { withThemeFromJSXProvider } from '@storybook/addon-styling';
-import {darkTheme, theme, GlobalStyle} from 'styles'
+import { darkTheme, theme, GlobalStyle } from '../src/styles';
 
 const preview: Preview = {
   parameters: {
@@ -37,8 +37,8 @@ const preview: Preview = {
       },
       defaultTheme: 'light',
       Provider: ThemeProvider,
-      GlobalStyles: GlobalStyle
-    })
+      GlobalStyles: GlobalStyle,
+    }),
   ],
 };
 

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -4,13 +4,13 @@ import { ThemeProvider } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { useDarkState } from 'stores';
-import { theme, darktheme, GlobalStyle } from 'styles';
+import { theme, darkTheme, GlobalStyle } from 'styles';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const { isDark } = useDarkState();
 
   return (
-    <ThemeProvider theme={isDark ? darktheme : theme}>
+    <ThemeProvider theme={isDark ? darkTheme : theme}>
       <GlobalStyle />
       <AppWrapper>{children}</AppWrapper>
     </ThemeProvider>

--- a/src/components/MobileCard/style.ts
+++ b/src/components/MobileCard/style.ts
@@ -81,14 +81,11 @@ export const Slide = styled.div`
 `;
 
 export const Categories = styled.div`
-  height: 1.875rem;
-  overflow-y: hidden;
+  width: 100%;
+  overflow-x: hidden;
   display: flex;
   justify-content: center;
   align-items: center;
-  @media (max-width: 897px) {
-    width: 100%;
-  }
 `;
 
 export const DetailBtn = styled.h2`

--- a/src/components/MobileCard/style.ts
+++ b/src/components/MobileCard/style.ts
@@ -18,13 +18,11 @@ export const MobileCard = styled.div<{ isDark: boolean }>`
   position: relative;
   box-sizing: border-box;
   background-color: #fff;
-  margin-bottom: 0.75rem;
   transition: ease-in-out 0.3s;
   background-color: ${({ theme }) => theme.exception.card};
 `;
 
 export const ContentWrap = styled.div`
-  position: absolute;
   left: 5.6%;
   width: 73vw;
   height: 15vw;

--- a/src/components/MobileCard/style.ts
+++ b/src/components/MobileCard/style.ts
@@ -11,7 +11,6 @@ const slide = keyframes`
 
 export const MobileCard = styled.div<{ isDark: boolean }>`
   width: 100%;
-  height: 10vh;
   border-radius: 0.625rem;
   display: flex;
   align-items: center;
@@ -19,6 +18,7 @@ export const MobileCard = styled.div<{ isDark: boolean }>`
   box-sizing: border-box;
   background-color: #fff;
   transition: ease-in-out 0.3s;
+  padding: 1rem 0 1rem 1rem;
   background-color: ${({ theme }) => theme.exception.card};
 `;
 

--- a/src/components/MobileCard/style.ts
+++ b/src/components/MobileCard/style.ts
@@ -102,4 +102,5 @@ export const DetailBtn = styled.h2`
   z-index: 99999;
   line-height: 1.125rem;
   color: #999999;
+  cursor: pointer;
 `;

--- a/src/components/Slide/Mobile/index.stories.tsx
+++ b/src/components/Slide/Mobile/index.stories.tsx
@@ -1,0 +1,13 @@
+import Mobile from '.';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+export default {
+  title: 'Slide/Mobile',
+  component: Mobile,
+  parameters: {},
+} as Meta<typeof Mobile>;
+
+type Story = StoryObj<typeof Mobile>;
+
+export const Primary: Story = {};

--- a/src/components/Slide/Mobile/index.tsx
+++ b/src/components/Slide/Mobile/index.tsx
@@ -1,0 +1,14 @@
+/** @jsxImportSource @emotion/react */
+
+'use client';
+
+import { useState } from 'react';
+
+const Moblie = () => {
+  const [slideIndex, setSlideIndex] = useState<number>(0);
+  const [tabletCardBox, setTabletCardBox] = useState<number>(3);
+
+  return <></>;
+};
+
+export default Moblie;

--- a/src/components/Slide/Mobile/index.tsx
+++ b/src/components/Slide/Mobile/index.tsx
@@ -2,13 +2,19 @@
 
 'use client';
 
-import { useState } from 'react';
+import { MobileCard } from 'components';
+import project from 'constants/project.json';
 
-const Moblie = () => {
-  const [slideIndex, setSlideIndex] = useState<number>(0);
-  const [tabletCardBox, setTabletCardBox] = useState<number>(3);
-
-  return <></>;
-};
+import * as S from './style';
+const Moblie = () => (
+  <>
+    <S.MobileCardTitle>등록된 프로젝트</S.MobileCardTitle>
+    <S.MobileCardWrap>
+      {project.map(data => (
+        <MobileCard key={data.id} data={data} />
+      ))}
+    </S.MobileCardWrap>
+  </>
+);
 
 export default Moblie;

--- a/src/components/Slide/Mobile/style.ts
+++ b/src/components/Slide/Mobile/style.ts
@@ -1,0 +1,1 @@
+import styled from '@emotion/styled';

--- a/src/components/Slide/Mobile/style.ts
+++ b/src/components/Slide/Mobile/style.ts
@@ -1,1 +1,17 @@
 import styled from '@emotion/styled';
+
+export const MobileCardWrap = styled.div`
+  width: 87.6vw;
+  height: 10vh;
+`;
+
+export const MobileCardTitle = styled.h2`
+  font-style: normal;
+  font-weight: 600;
+  font-size: 4vw;
+  line-height: 1.5625rem;
+  letter-spacing: -0.03em;
+  color: ${({ theme }) => theme.exception.cardTitle};
+  margin-bottom: 0.75rem;
+  width: 87.6vw;
+`;

--- a/src/components/Slide/Mobile/style.ts
+++ b/src/components/Slide/Mobile/style.ts
@@ -2,9 +2,13 @@ import styled from '@emotion/styled';
 
 export const MobileCardWrap = styled.div`
   width: 87.6vw;
+  height: 100vh;
+  position: relative;
+  overflow: scroll;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0.5rem;
+  padding-bottom: 5rem;
 `;
 
 export const MobileCardTitle = styled.h2`

--- a/src/components/Slide/Mobile/style.ts
+++ b/src/components/Slide/Mobile/style.ts
@@ -2,7 +2,9 @@ import styled from '@emotion/styled';
 
 export const MobileCardWrap = styled.div`
   width: 87.6vw;
-  height: 10vh;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 `;
 
 export const MobileCardTitle = styled.h2`

--- a/src/components/Slide/PC/index.stories.tsx
+++ b/src/components/Slide/PC/index.stories.tsx
@@ -1,0 +1,13 @@
+import PC from '.';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+export default {
+  title: 'Slide/PC',
+  component: PC,
+  parameters: {},
+} as Meta<typeof PC>;
+
+type Story = StoryObj<typeof PC>;
+
+export const Primary: Story = {};

--- a/src/components/Slide/PC/index.tsx
+++ b/src/components/Slide/PC/index.tsx
@@ -1,0 +1,14 @@
+/** @jsxImportSource @emotion/react */
+
+'use client';
+
+import { useState } from 'react';
+
+const PC = () => {
+  const [slideIndex, setSlideIndex] = useState<number>(0);
+  const [tabletCardBox, setTabletCardBox] = useState<number>(3);
+
+  return <></>;
+};
+
+export default PC;

--- a/src/components/Slide/PC/style.ts
+++ b/src/components/Slide/PC/style.ts
@@ -1,0 +1,1 @@
+import styled from '@emotion/styled';

--- a/src/components/Slide/Tablet/index.stories.tsx
+++ b/src/components/Slide/Tablet/index.stories.tsx
@@ -1,0 +1,13 @@
+import Tablet from '.';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+export default {
+  title: 'Slide/Tablet',
+  component: Tablet,
+  parameters: {},
+} as Meta<typeof Tablet>;
+
+type Story = StoryObj<typeof Tablet>;
+
+export const Primary: Story = {};

--- a/src/components/Slide/Tablet/index.tsx
+++ b/src/components/Slide/Tablet/index.tsx
@@ -1,0 +1,14 @@
+/** @jsxImportSource @emotion/react */
+
+'use client';
+
+import { useState } from 'react';
+
+const Tablet = () => {
+  const [slideIndex, setSlideIndex] = useState<number>(0);
+  const [tabletCardBox, setTabletCardBox] = useState<number>(3);
+
+  return <></>;
+};
+
+export default Tablet;

--- a/src/components/Slide/Tablet/style.ts
+++ b/src/components/Slide/Tablet/style.ts
@@ -1,0 +1,1 @@
+import styled from '@emotion/styled';

--- a/src/components/Slide/index.ts
+++ b/src/components/Slide/index.ts
@@ -1,0 +1,3 @@
+export { default as MobileSlide } from './Mobile';
+export { default as PCSlide } from './PC';
+export { default as TabletSlide } from './Tablet';

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -29,7 +29,7 @@ export interface ThemeType {
   };
 }
 
-export const darktheme: ThemeType = {
+export const darkTheme: ThemeType = {
   gray: ['#191919', '#636363', '#999999', '#E3E3E3', '#F1F1F5'],
   primary: {
     magenta: '#E23C96',


### PR DESCRIPTION
## 개요 💡

> mobile size의 card list를 분리했습니다.

## 작업내용 ⌨️

보다 효율적인 컴포넌트 관리를 위해 각 berak point별로 card list를 분리합니다.
Slide 디렉토리의 틀을 생성하였고 mobile size card list를 분리하였습니다.
+ storybook의 `Slide/Mobile`에서 확인 가능합니다.
mobile card list는 620px부터 적용됩니다.

## BuildError
PC와 tablet size의 컴포넌트들을 구조만 잡아놓아서 build error가 생기는것 같습니다.
이후의 작업에서 해결 하겠습니다.