### PR TITLE
tablet slide

### DIFF
--- a/src/components/Card/style.ts
+++ b/src/components/Card/style.ts
@@ -10,7 +10,6 @@ export const CardWrapper = styled.div`
   flex-direction: column;
   border-radius: 1rem;
   box-shadow: rgba(112, 144, 176, 0.2);
-  transition: ease-in-out 0.3s;
   background-color: ${({ theme }) => theme.exception.card};
   box-shadow: 0.25rem 0.25rem 0.4375rem rgba(112, 144, 176, 0.2);
 

--- a/src/components/Slide/PC/index.tsx
+++ b/src/components/Slide/PC/index.tsx
@@ -11,10 +11,12 @@ import project from 'constants/project.json';
 
 import * as S from './style';
 
+const CARDSPERPAGE = 3 as const;
+
 const PC = () => {
   const [slideIndex, setSlideIndex] = useState<number>(0);
 
-  const maxIndex = Math.ceil(project.length / 3) - 1;
+  const maxIndex = Math.ceil(project.length / CARDSPERPAGE) - 1;
 
   const handlePrevSlide = () => {
     if (slideIndex === 0) {

--- a/src/components/Slide/PC/index.tsx
+++ b/src/components/Slide/PC/index.tsx
@@ -11,12 +11,12 @@ import project from 'constants/project.json';
 
 import * as S from './style';
 
-const CARDSPERPAGE = 3 as const;
+const CARDS_PER_PAGE = 3 as const;
 
 const PC = () => {
   const [slideIndex, setSlideIndex] = useState<number>(0);
 
-  const maxIndex = Math.ceil(project.length / CARDSPERPAGE) - 1;
+  const maxIndex = Math.ceil(project.length / CARDS_PER_PAGE) - 1;
 
   const handlePrevSlide = () => {
     if (slideIndex === 0) {

--- a/src/components/Slide/PC/index.tsx
+++ b/src/components/Slide/PC/index.tsx
@@ -14,18 +14,18 @@ import * as S from './style';
 const PC = () => {
   const [slideIndex, setSlideIndex] = useState<number>(0);
 
-  const getMaxIndex = () => Math.ceil(project.length / 3) - 1;
+  const maxIndex = Math.ceil(project.length / 3) - 1;
 
   const handlePrevSlide = () => {
     if (slideIndex === 0) {
-      setSlideIndex(getMaxIndex());
+      setSlideIndex(maxIndex);
     } else {
       setSlideIndex(curIndex => curIndex - 1);
     }
   };
 
   const handleNextSlide = () => {
-    if (getMaxIndex() === slideIndex) {
+    if (maxIndex === slideIndex) {
       setSlideIndex(0);
     } else {
       setSlideIndex(curIndex => curIndex + 1);

--- a/src/components/Slide/Tablet/index.tsx
+++ b/src/components/Slide/Tablet/index.tsx
@@ -11,12 +11,12 @@ import project from 'constants/project.json';
 
 import * as S from './style';
 
-const CARDSPERPAGE = 4 as const;
+const CARDS_PER_PAGE = 4 as const;
 
 const Tablet = () => {
   const [slideIndex, setSlideIndex] = useState<number>(0);
 
-  const maxIndex = Math.ceil(project.length / CARDSPERPAGE) - 1;
+  const maxIndex = Math.ceil(project.length / CARDS_PER_PAGE) - 1;
 
   const handlePrevSlide = () => {
     if (slideIndex === 0) {

--- a/src/components/Slide/Tablet/index.tsx
+++ b/src/components/Slide/Tablet/index.tsx
@@ -4,11 +4,61 @@
 
 import { useState } from 'react';
 
+import Image from 'next/image';
+
+import { Card } from 'components';
+import project from 'constants/project.json';
+
+import * as S from './style';
+
 const Tablet = () => {
   const [slideIndex, setSlideIndex] = useState<number>(0);
-  const [tabletCardBox, setTabletCardBox] = useState<number>(3);
 
-  return <></>;
+  const getMaxIndex = () => Math.ceil(project.length / 4) - 1;
+
+  const handlePrevSlide = () => {
+    if (slideIndex === 0) {
+      setSlideIndex(getMaxIndex());
+    } else {
+      setSlideIndex(curIndex => curIndex - 1);
+    }
+  };
+
+  const handleNextSlide = () => {
+    if (getMaxIndex() === slideIndex) {
+      setSlideIndex(0);
+    } else {
+      setSlideIndex(curIndex => curIndex + 1);
+    }
+  };
+
+  return (
+    <S.CardContainer>
+      <S.VectorWrapper>
+        <Image
+          fill
+          src="/images/Vector.svg"
+          alt="Vector"
+          onClick={handlePrevSlide}
+        />
+      </S.VectorWrapper>
+      <S.Cards>
+        <S.MoveContainer slideIndex={slideIndex}>
+          {project.map((data, slideIndex) => (
+            <Card key={slideIndex + data.id} data={data} />
+          ))}
+        </S.MoveContainer>
+      </S.Cards>
+      <S.VectorWrapper isRight={true}>
+        <Image
+          fill
+          src="/images/Vector.svg"
+          alt="Vector"
+          onClick={handleNextSlide}
+        />
+      </S.VectorWrapper>
+    </S.CardContainer>
+  );
 };
 
 export default Tablet;

--- a/src/components/Slide/Tablet/index.tsx
+++ b/src/components/Slide/Tablet/index.tsx
@@ -43,11 +43,13 @@ const Tablet = () => {
         />
       </S.VectorWrapper>
       <S.Cards>
-        <S.MoveContainer slideIndex={slideIndex}>
-          {project.map((data, slideIndex) => (
-            <Card key={slideIndex + data.id} data={data} />
-          ))}
-        </S.MoveContainer>
+        <S.Slider slideIndex={slideIndex}>
+          <S.MoveContainer>
+            {project.map((data, slideIndex) => (
+              <Card key={slideIndex + data.id} data={data} />
+            ))}
+          </S.MoveContainer>
+        </S.Slider>
       </S.Cards>
       <S.VectorWrapper isRight={true}>
         <Image

--- a/src/components/Slide/Tablet/index.tsx
+++ b/src/components/Slide/Tablet/index.tsx
@@ -14,18 +14,18 @@ import * as S from './style';
 const Tablet = () => {
   const [slideIndex, setSlideIndex] = useState<number>(0);
 
-  const getMaxIndex = () => Math.ceil(project.length / 4) - 1;
+  const maxIndex = Math.ceil(project.length / 4) - 1;
 
   const handlePrevSlide = () => {
     if (slideIndex === 0) {
-      setSlideIndex(getMaxIndex());
+      setSlideIndex(maxIndex);
     } else {
       setSlideIndex(curIndex => curIndex - 1);
     }
   };
 
   const handleNextSlide = () => {
-    if (getMaxIndex() === slideIndex) {
+    if (maxIndex === slideIndex) {
       setSlideIndex(0);
     } else {
       setSlideIndex(curIndex => curIndex + 1);
@@ -44,7 +44,7 @@ const Tablet = () => {
       </S.VectorWrapper>
       <S.Cards>
         <S.Slider slideIndex={slideIndex}>
-          <S.MoveContainer>
+          <S.MoveContainer maxIndex={maxIndex}>
             {project.map((data, slideIndex) => (
               <Card key={slideIndex + data.id} data={data} />
             ))}

--- a/src/components/Slide/Tablet/index.tsx
+++ b/src/components/Slide/Tablet/index.tsx
@@ -11,10 +11,12 @@ import project from 'constants/project.json';
 
 import * as S from './style';
 
+const CARDSPERPAGE = 4 as const;
+
 const Tablet = () => {
   const [slideIndex, setSlideIndex] = useState<number>(0);
 
-  const maxIndex = Math.ceil(project.length / 4) - 1;
+  const maxIndex = Math.ceil(project.length / CARDSPERPAGE) - 1;
 
   const handlePrevSlide = () => {
     if (slideIndex === 0) {

--- a/src/components/Slide/Tablet/style.ts
+++ b/src/components/Slide/Tablet/style.ts
@@ -1,1 +1,36 @@
 import styled from '@emotion/styled';
+
+export const CardContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 2.25rem;
+  transition: ease-in-out 0.3s;
+`;
+
+export const VectorWrapper = styled.div<{ isRight?: boolean }>`
+  width: 2.5rem;
+  height: 3rem;
+  position: relative;
+  overflow: hidden;
+  cursor: pointer;
+  ${({ isRight }) => isRight && 'transform: matrix(-1, 0, 0, 1, 0, 0);'}
+`;
+
+export const Cards = styled.div`
+  width: 90vw;
+  height: 100vh;
+  position: relative;
+  /* overflow: hidden; */
+`;
+
+export const MoveContainer = styled.div<{ slideIndex: number }>`
+  display: grid;
+  grid-template-rows: repeat(2, 1fr); /* 2개의 행을 생성합니다. */
+  /* grid-template-columns: repeat(2, 1fr); /* 2개의 열을 생성합니다. */
+  /* grid-template-rows: repeat(2, 1fr);  */
+  gap: 1.75rem;
+  position: absolute;
+  /* left: -${({ slideIndex }) => slideIndex * 72.75}rem; */
+  transition: ease-in-out 0.3s;
+`;

--- a/src/components/Slide/Tablet/style.ts
+++ b/src/components/Slide/Tablet/style.ts
@@ -28,12 +28,16 @@ export const Cards = styled.div`
   overflow: hidden;
 `;
 
-export const MoveContainer = styled.div<{ slideIndex: number }>`
+export const Slider = styled.div<{ slideIndex: number }>`
+  position: absolute;
+  left: ${({ slideIndex }) =>
+    `calc(${slideIndex * -76}vw + ${slideIndex * -3.5}rem)`};
+  transition: ease-in-out 0.3s;
+`;
+
+export const MoveContainer = styled.div`
   display: grid;
-  grid-template-columns: repeat(10, 1fr);
+  grid-template-columns: repeat(8, 1fr);
   grid-template-rows: repeat(2, 1fr);
   gap: 1.75rem;
-  position: absolute;
-  /* left: -${({ slideIndex }) => slideIndex * 72.75}rem; */
-  transition: ease-in-out 0.3s;
 `;

--- a/src/components/Slide/Tablet/style.ts
+++ b/src/components/Slide/Tablet/style.ts
@@ -35,9 +35,9 @@ export const Slider = styled.div<{ slideIndex: number }>`
   transition: ease-in-out 0.3s;
 `;
 
-export const MoveContainer = styled.div`
+export const MoveContainer = styled.div<{ maxIndex: number }>`
   display: grid;
-  grid-template-columns: repeat(8, 1fr);
+  grid-template-columns: repeat(${({ maxIndex }) => (maxIndex + 1) * 2}, 1fr);
   grid-template-rows: repeat(2, 1fr);
   gap: 1.75rem;
 `;

--- a/src/components/Slide/Tablet/style.ts
+++ b/src/components/Slide/Tablet/style.ts
@@ -6,6 +6,10 @@ export const CardContainer = styled.div`
   align-items: center;
   gap: 2.25rem;
   transition: ease-in-out 0.3s;
+
+  @media (max-width: 900px) {
+    gap: 0;
+  }
 `;
 
 export const VectorWrapper = styled.div<{ isRight?: boolean }>`
@@ -18,17 +22,16 @@ export const VectorWrapper = styled.div<{ isRight?: boolean }>`
 `;
 
 export const Cards = styled.div`
-  width: 90vw;
-  height: 100vh;
+  width: calc(76vw + 1.75rem);
+  height: calc(76vw + 1.75rem);
   position: relative;
-  /* overflow: hidden; */
+  overflow: hidden;
 `;
 
 export const MoveContainer = styled.div<{ slideIndex: number }>`
   display: grid;
-  grid-template-rows: repeat(2, 1fr); /* 2개의 행을 생성합니다. */
-  /* grid-template-columns: repeat(2, 1fr); /* 2개의 열을 생성합니다. */
-  /* grid-template-rows: repeat(2, 1fr);  */
+  grid-template-columns: repeat(10, 1fr);
+  grid-template-rows: repeat(2, 1fr);
   gap: 1.75rem;
   position: absolute;
   /* left: -${({ slideIndex }) => slideIndex * 72.75}rem; */


### PR DESCRIPTION
## 개요 💡

> tablet size slide를 분리했습니다.
## 작업내용 ⌨️
보다 효율적인 컴포넌트 관리를 위해 각 berak point별로 card list를 분리합니다.
이 PR에서는 PC size slide를 분리했습니다.

- Storybook Slide/PC에서 확인 가능합니다.
- tablet size는 1150px부터 620px까지 적용됩니다.

<img width="995" alt="image" src="https://github.com/themoment-team/EveryGSM-client/assets/106712562/6c075f28-ed7b-486a-b9f9-aed1da8462bc">

### 모든 size slide 분리가 되었습니다. 이후 PR에서 window size에 따라 렌더링시키고 반응형 개선하는 작업 하겠습니다.