### PR TITLE
Fix cardSlide

### DIFF
--- a/src/components/Slide/PC/index.tsx
+++ b/src/components/Slide/PC/index.tsx
@@ -2,8 +2,7 @@
 
 import { useState } from 'react';
 
-import { Vector } from 'assets';
-import { Card } from 'components';
+import { Card, SlideController } from 'components';
 import { useFilterProjects, useHandleSlide } from 'hooks';
 
 import * as S from './style';
@@ -24,9 +23,7 @@ const PC = () => {
 
   return (
     <S.CardContainer>
-      <S.PrevController type="button" onClick={handlePrevSlide}>
-        <Vector />
-      </S.PrevController>
+      <SlideController view="PC" onClick={handlePrevSlide} direction="left" />
       <S.Cards>
         <S.MoveContainer slideIndex={slideIndex}>
           {projects.map((data, slideIndex) => (
@@ -34,9 +31,7 @@ const PC = () => {
           ))}
         </S.MoveContainer>
       </S.Cards>
-      <S.NextController type="button" onClick={handleNextSlide}>
-        <Vector />
-      </S.NextController>
+      <SlideController view="PC" onClick={handleNextSlide} direction="left" />
     </S.CardContainer>
   );
 };

--- a/src/components/Slide/PC/index.tsx
+++ b/src/components/Slide/PC/index.tsx
@@ -31,7 +31,7 @@ const PC = () => {
           ))}
         </S.MoveContainer>
       </S.Cards>
-      <SlideController view="PC" onClick={handleNextSlide} direction="left" />
+      <SlideController view="PC" onClick={handleNextSlide} direction="right" />
     </S.CardContainer>
   );
 };

--- a/src/components/Slide/PC/index.tsx
+++ b/src/components/Slide/PC/index.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { Vector } from 'assets';
 import { Card } from 'components';
-import { useFilterProjects } from 'hooks';
+import { useFilterProjects, useHandleSlide } from 'hooks';
 
 import * as S from './style';
 
@@ -17,21 +17,10 @@ const PC = () => {
 
   const maxIndex = Math.ceil(projects.length / CARDS_PER_PAGE) - 1;
 
-  const handlePrevSlide = () => {
-    if (slideIndex === 0) {
-      setSlideIndex(maxIndex);
-    } else {
-      setSlideIndex(curIndex => curIndex - 1);
-    }
-  };
-
-  const handleNextSlide = () => {
-    if (maxIndex === slideIndex) {
-      setSlideIndex(0);
-    } else {
-      setSlideIndex(curIndex => curIndex + 1);
-    }
-  };
+  const { handleNextSlide, handlePrevSlide } = useHandleSlide(
+    maxIndex,
+    setSlideIndex,
+  );
 
   return (
     <S.CardContainer>

--- a/src/components/Slide/Tablet/index.tsx
+++ b/src/components/Slide/Tablet/index.tsx
@@ -2,8 +2,7 @@
 
 import { useState } from 'react';
 
-import { Vector } from 'assets';
-import { Card } from 'components';
+import { Card, SlideController } from 'components';
 import { useFilterProjects, useHandleSlide } from 'hooks';
 
 import * as S from './style';
@@ -24,9 +23,11 @@ const Tablet = () => {
 
   return (
     <S.CardContainer>
-      <S.PrevController type="button" onClick={handlePrevSlide}>
-        <Vector />
-      </S.PrevController>
+      <SlideController
+        view="TABLET"
+        onClick={handlePrevSlide}
+        direction="left"
+      />
       <S.Cards>
         <S.Slider slideIndex={slideIndex}>
           <S.MoveContainer maxIndex={maxIndex}>
@@ -36,9 +37,11 @@ const Tablet = () => {
           </S.MoveContainer>
         </S.Slider>
       </S.Cards>
-      <S.NextController type="button" onClick={handleNextSlide}>
-        <Vector />
-      </S.NextController>
+      <SlideController
+        view="TABLET"
+        onClick={handleNextSlide}
+        direction="right"
+      />
     </S.CardContainer>
   );
 };

--- a/src/components/Slide/Tablet/index.tsx
+++ b/src/components/Slide/Tablet/index.tsx
@@ -22,22 +22,6 @@ const Tablet = () => {
     setSlideIndex,
   );
 
-  const handlePrevSlide = () => {
-    if (slideIndex === 0) {
-      setSlideIndex(maxIndex);
-    } else {
-      setSlideIndex(curIndex => curIndex - 1);
-    }
-  };
-
-  const handleNextSlide = () => {
-    if (maxIndex === slideIndex) {
-      setSlideIndex(0);
-    } else {
-      setSlideIndex(curIndex => curIndex + 1);
-    }
-  };
-
   return (
     <S.CardContainer>
       <S.PrevController type="button" onClick={handlePrevSlide}>

--- a/src/components/Slide/Tablet/index.tsx
+++ b/src/components/Slide/Tablet/index.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { Vector } from 'assets';
 import { Card } from 'components';
-import { useFilterProjects } from 'hooks';
+import { useFilterProjects, useHandleSlide } from 'hooks';
 
 import * as S from './style';
 
@@ -16,6 +16,11 @@ const Tablet = () => {
   const projects = useFilterProjects({ setSlideIndex });
 
   const maxIndex = Math.ceil(projects.length / CARDS_PER_PAGE) - 1;
+
+  const { handleNextSlide, handlePrevSlide } = useHandleSlide(
+    maxIndex,
+    setSlideIndex,
+  );
 
   const handlePrevSlide = () => {
     if (slideIndex === 0) {

--- a/src/components/Slide/Tablet/style.ts
+++ b/src/components/Slide/Tablet/style.ts
@@ -45,23 +45,3 @@ export const MoveContainer = styled.div<{ maxIndex: number }>`
   grid-template-rows: repeat(2, 1fr);
   gap: 1.75rem;
 `;
-
-export const Controller = styled.button`
-  border: none;
-  z-index: 1;
-  cursor: pointer;
-  transition: background-color 0.3s ease-in-out;
-  background-color: ${({ theme }) => theme.gray[0]};
-`;
-
-export const PrevController = styled(Controller)`
-  margin-right: 1.875rem;
-`;
-
-export const NextController = styled(Controller)`
-  margin-left: 1.875rem;
-
-  svg {
-    transform: matrix(-1, 0, 0, 1, 0, 0);
-  }
-`;

--- a/src/components/SlideController/index.stories.tsx
+++ b/src/components/SlideController/index.stories.tsx
@@ -18,6 +18,7 @@ export const Left: Story = {
   args: {
     direction: 'left',
     onClick: () => {},
+    view: 'TABLET',
   },
 };
 
@@ -25,5 +26,14 @@ export const Right: Story = {
   args: {
     direction: 'right',
     onClick: () => {},
+    view: 'TABLET',
+  },
+};
+
+export const PC: Story = {
+  args: {
+    direction: 'right',
+    onClick: () => {},
+    view: 'PC',
   },
 };

--- a/src/components/SlideController/index.stories.tsx
+++ b/src/components/SlideController/index.stories.tsx
@@ -1,0 +1,29 @@
+import SlideController from '.';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+export default {
+  title: 'SlideController',
+  component: SlideController,
+  parameters: {
+    backgrounds: {
+      default: 'dark',
+    },
+  },
+} as Meta<typeof SlideController>;
+
+type Story = StoryObj<typeof SlideController>;
+
+export const Left: Story = {
+  args: {
+    direction: 'left',
+    onClick: () => {},
+  },
+};
+
+export const Right: Story = {
+  args: {
+    direction: 'right',
+    onClick: () => {},
+  },
+};

--- a/src/components/SlideController/index.tsx
+++ b/src/components/SlideController/index.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { Vector } from 'assets';
+
+import * as S from './style';
+
+interface Props {
+  direction: 'left' | 'right';
+  onClick: () => void;
+}
+
+const SlideController: React.FC<Props> = ({ direction, onClick }) => {
+  const Controller = direction === 'left' ? S.PrevController : S.NextController;
+
+  return (
+    <Controller type="button" onClick={onClick}>
+      <Vector />
+    </Controller>
+  );
+};
+
+export default SlideController;

--- a/src/components/SlideController/index.tsx
+++ b/src/components/SlideController/index.tsx
@@ -7,13 +7,14 @@ import * as S from './style';
 interface Props {
   direction: 'left' | 'right';
   onClick: () => void;
+  view: 'PC' | 'TABLET';
 }
 
-const SlideController: React.FC<Props> = ({ direction, onClick }) => {
+const SlideController: React.FC<Props> = ({ direction, onClick, view }) => {
   const Controller = direction === 'left' ? S.PrevController : S.NextController;
 
   return (
-    <Controller type="button" onClick={onClick}>
+    <Controller type="button" onClick={onClick} view={view}>
       <Vector />
     </Controller>
   );

--- a/src/components/SlideController/style.ts
+++ b/src/components/SlideController/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-export const Controller = styled.button`
+export const Controller = styled.button<{ view: 'PC' | 'TABLET' }>`
   border: none;
   z-index: 1;
   cursor: pointer;
@@ -9,11 +9,11 @@ export const Controller = styled.button`
 `;
 
 export const PrevController = styled(Controller)`
-  margin-right: 1.875rem;
+  margin-right: ${({ view }) => (view === 'PC' ? '3.125rem' : '1.875rem')};
 `;
 
 export const NextController = styled(Controller)`
-  margin-left: 1.875rem;
+  margin-left: ${({ view }) => (view === 'PC' ? '3.125rem' : '1.875rem')};
 
   svg {
     transform: matrix(-1, 0, 0, 1, 0, 0);

--- a/src/components/SlideController/style.ts
+++ b/src/components/SlideController/style.ts
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled';
+
+export const Controller = styled.button`
+  border: none;
+  z-index: 1;
+  cursor: pointer;
+  transition: background-color 0.3s ease-in-out;
+  background-color: ${({ theme }) => theme.gray[0]};
+`;
+
+export const PrevController = styled(Controller)`
+  margin-right: 1.875rem;
+`;
+
+export const NextController = styled(Controller)`
+  margin-left: 1.875rem;
+
+  svg {
+    transform: matrix(-1, 0, 0, 1, 0, 0);
+  }
+`;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,4 +10,5 @@ export { default as Nav } from './Nav';
 export { default as NavigationEvents } from './NavigationEvents';
 export { default as PCSlide } from './Slide/PC';
 export { default as SearchBar } from './SearchBar';
+export { default as SlideController } from './SlideController';
 export { default as TabletSlide } from './Slide/Tablet';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { default as useFilterProjects } from './useFilterProjects';
+export { default as useHandleSlide } from './useHandleSlide';
 export { default as useWindowResizeEffect } from './useWindowResizeEffect';

--- a/src/hooks/useHandleSlide.ts
+++ b/src/hooks/useHandleSlide.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import type { Dispatch, SetStateAction } from 'react';
+
+const useHandleSlide = (
+  maxIndex: number,
+  setSlideIndex: Dispatch<SetStateAction<number>>,
+) => {
+  const handlePrevSlide = () => {
+    setSlideIndex(curIndex => (curIndex === 0 ? maxIndex : curIndex - 1));
+  };
+
+  const handleNextSlide = () => {
+    setSlideIndex(curIndex => (curIndex === maxIndex ? 0 : curIndex + 1));
+  };
+
+  return {
+    handlePrevSlide,
+    handleNextSlide,
+  };
+};
+
+export default useHandleSlide;


### PR DESCRIPTION
## 개요 💡

> 기존 카드 슬라이드를 개선했습니다.

## 작업내용 ⌨️

최초의 카드 슬라이드는 모든 view의 UI가 섞여 있어 굉장히 복잡한 형태였습니다. 이를 이전에 각 view의 UI별로 분리하였지만, PC UI와 TABLET UI의 겹치는 코드가 있어 이를 모듈화 하였습니다.

- SlideController 컴포넌트를 제작하여 중복되는 컨트롤러 코드를 줄였습니다.
- useHandleSlide hook을 제작하여 슬라이드 이동 로직만 담당하도록 하였습니다.